### PR TITLE
Improve convert_examples in mutiprocess mode

### DIFF
--- a/simpletransformers/ner/ner_utils.py
+++ b/simpletransformers/ner/ner_utils.py
@@ -472,7 +472,6 @@ def convert_examples_to_features(
                     p.imap(
                         convert_examples_with_multiprocessing,
                         examples,
-                        chunksize=chunksize,
                     ),
                     total=len(examples),
                     disable=silent,


### PR DESCRIPTION
line 475
In p.imap, `chunksize` means that the objects in `examples` are allocated to each process with the size of `chunksize`, but each object in `examples` has been chunked before, resulting in almost all data running in a single process.

For example, when `chunksize`=500 and the amount of data is 5000, then `examples` should be a 10 * 500 list. When entering p.imap, the same `chunksize` parameter will consider 500*500 pieces of data as a chunk, which results in almost all data being completed in one process, resulting in the same speed as a single process or even slower.

So my way of handling it is not to use the `chunksize` parameter in imap, because the data is already chunked in the previous step.